### PR TITLE
Fix issue where only 1 aux effect was being heard

### DIFF
--- a/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
+++ b/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
@@ -54,6 +54,7 @@ public class SoundPhysics {
 
     private static SoundSource lastSoundCategory;
     private static String lastSoundName;
+    private static int maxAuxSends;
 
     public static void init() {
         LOGGER.info("Initializing Sound Physics");
@@ -82,6 +83,9 @@ public class SoundPhysics {
             LOGGER.error("EFX Extension not found on current device. Aborting.");
             return;
         }
+
+        maxAuxSends = ALC10.alcGetInteger(currentDevice, EXTEfx.ALC_MAX_AUXILIARY_SENDS);
+        LOGGER.info("Max auxiliary sends: {}", maxAuxSends);
 
         // Create auxiliary effect slots
         auxFXSlot0 = EXTEfx.alGenAuxiliaryEffectSlots();
@@ -514,25 +518,34 @@ public class SoundPhysics {
             return;
         }
         // Set reverb send filter values and set source to send to all reverb fx slots
-        EXTEfx.alFilterf(sendFilter0, EXTEfx.AL_LOWPASS_GAIN, sendGain0);
-        EXTEfx.alFilterf(sendFilter0, EXTEfx.AL_LOWPASS_GAINHF, sendCutoff0);
-        AL11.alSource3i(sourceID, EXTEfx.AL_AUXILIARY_SEND_FILTER, auxFXSlot0, 1, sendFilter0);
-        logALError("Set environment filter0:");
 
-        EXTEfx.alFilterf(sendFilter1, EXTEfx.AL_LOWPASS_GAIN, sendGain1);
-        EXTEfx.alFilterf(sendFilter1, EXTEfx.AL_LOWPASS_GAINHF, sendCutoff1);
-        AL11.alSource3i(sourceID, EXTEfx.AL_AUXILIARY_SEND_FILTER, auxFXSlot1, 1, sendFilter1);
-        logALError("Set environment filter1:");
+        if (maxAuxSends >= 4) {
+            EXTEfx.alFilterf(sendFilter0, EXTEfx.AL_LOWPASS_GAIN, sendGain0);
+            EXTEfx.alFilterf(sendFilter0, EXTEfx.AL_LOWPASS_GAINHF, sendCutoff0);
+            AL11.alSource3i(sourceID, EXTEfx.AL_AUXILIARY_SEND_FILTER, auxFXSlot0, 3, sendFilter0);
+            logALError("Set environment filter0:");
+        }
 
-        EXTEfx.alFilterf(sendFilter2, EXTEfx.AL_LOWPASS_GAIN, sendGain2);
-        EXTEfx.alFilterf(sendFilter2, EXTEfx.AL_LOWPASS_GAINHF, sendCutoff2);
-        AL11.alSource3i(sourceID, EXTEfx.AL_AUXILIARY_SEND_FILTER, auxFXSlot2, 1, sendFilter2);
-        logALError("Set environment filter2:");
+        if (maxAuxSends >= 3) {
+            EXTEfx.alFilterf(sendFilter1, EXTEfx.AL_LOWPASS_GAIN, sendGain1);
+            EXTEfx.alFilterf(sendFilter1, EXTEfx.AL_LOWPASS_GAINHF, sendCutoff1);
+            AL11.alSource3i(sourceID, EXTEfx.AL_AUXILIARY_SEND_FILTER, auxFXSlot1, 2, sendFilter1);
+            logALError("Set environment filter1:");
+        }
 
-        EXTEfx.alFilterf(sendFilter3, EXTEfx.AL_LOWPASS_GAIN, sendGain3);
-        EXTEfx.alFilterf(sendFilter3, EXTEfx.AL_LOWPASS_GAINHF, sendCutoff3);
-        AL11.alSource3i(sourceID, EXTEfx.AL_AUXILIARY_SEND_FILTER, auxFXSlot3, 1, sendFilter3);
-        logALError("Set environment filter3:");
+        if (maxAuxSends >= 2) {
+            EXTEfx.alFilterf(sendFilter2, EXTEfx.AL_LOWPASS_GAIN, sendGain2);
+            EXTEfx.alFilterf(sendFilter2, EXTEfx.AL_LOWPASS_GAINHF, sendCutoff2);
+            AL11.alSource3i(sourceID, EXTEfx.AL_AUXILIARY_SEND_FILTER, auxFXSlot2, 1, sendFilter2);
+            logALError("Set environment filter2:");
+        }
+
+        if (maxAuxSends >= 1) {
+            EXTEfx.alFilterf(sendFilter3, EXTEfx.AL_LOWPASS_GAIN, sendGain3);
+            EXTEfx.alFilterf(sendFilter3, EXTEfx.AL_LOWPASS_GAINHF, sendCutoff3);
+            AL11.alSource3i(sourceID, EXTEfx.AL_AUXILIARY_SEND_FILTER, auxFXSlot3, 0, sendFilter3);
+            logALError("Set environment filter3:");
+        }
 
         EXTEfx.alFilterf(directFilter0, EXTEfx.AL_LOWPASS_GAIN, directGain);
         EXTEfx.alFilterf(directFilter0, EXTEfx.AL_LOWPASS_GAINHF, directCutoff);

--- a/common/src/main/java/com/sonicether/soundphysics/mixin/LibraryMixin.java
+++ b/common/src/main/java/com/sonicether/soundphysics/mixin/LibraryMixin.java
@@ -1,0 +1,18 @@
+package com.sonicether.soundphysics.mixin;
+
+import com.mojang.blaze3d.audio.Library;
+import org.lwjgl.openal.ALC10;
+import org.lwjgl.openal.EXTEfx;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.nio.IntBuffer;
+
+@Mixin(Library.class)
+public class LibraryMixin {
+    @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lorg/lwjgl/openal/ALC10;alcCreateContext(JLjava/nio/IntBuffer;)J"))
+    private long requestAuxSends(long deviceHandle, IntBuffer attrList) {
+        return ALC10.alcCreateContext(deviceHandle, new int[]{EXTEfx.ALC_MAX_AUXILIARY_SENDS, 4, 0, 0});
+    }
+}

--- a/fabric/src/main/resources/sound_physics_remastered.mixins.json
+++ b/fabric/src/main/resources/sound_physics_remastered.mixins.json
@@ -11,7 +11,8 @@
   "client": [
     "SoundSystemMixin",
     "SourceMixin",
-    "DebugRendererMixin"
+    "DebugRendererMixin",
+    "LibraryMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/forge/src/main/resources/assets/sound_physics_remastered/sound_physics_remastered.mixins.json
+++ b/forge/src/main/resources/assets/sound_physics_remastered/sound_physics_remastered.mixins.json
@@ -12,7 +12,8 @@
   "client": [
     "SoundSystemMixin",
     "SourceMixin",
-    "DebugRendererMixin"
+    "DebugRendererMixin",
+    "LibraryMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
In SoundPhysics.setEnvironment, when a source's auxiliary feed is configured so an effect is heard, every auxiliary send number is conflictedly set to 1. This results in only the last effect of the 4 to be heard, which happens to be the effect with the largest reverb.

This fix should allow all 4 reverb effects to be heard now (personally I don't hear much of a dramatic difference, but at least the calculations for the gains/cutoffs are no longer in vain).