### PR TITLE
Update mods.toml to not cause red X when client-side only

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -12,6 +12,7 @@ version="${mod_version}"
 displayName="${mod_name}"
 updateJSONURL="https://maxhenkel.de/update/sound_physics_remastered.json"
 description='''Provides realistic sound attenuation, reverberation, and absorption through blocks.'''
+displayTest="IGNORE_ALL_VERSION"
 [[dependencies.${mod_id}]]
     modId="forge"
     mandatory=true


### PR DESCRIPTION
### Issue
Sound Physics Remastered causes the sidedness checker in Forge to throw a red X if the mod is only installed client-side, which of course is a problem when the mod isn't needed on the server (nor works if on the server).

### Solution
This may be a bit of a bandaid, but the solution here is to use Forge's `displayTest` parameter within mods.toml to ignore any X flagging. This is documented here: https://docs.minecraftforge.net/en/latest/concepts/sides/#writing-one-sided-mods