### PR TITLE
Fix block position evaluation

### DIFF
--- a/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
+++ b/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
@@ -236,7 +236,7 @@ public class SoundPhysics {
         Vec3 soundPos = new Vec3(posX, posY, posZ);
         Vec3 normalToPlayer = playerPos.subtract(soundPos).normalize();
 
-        BlockPos soundBlockPos = new BlockPos((int) soundPos.x, (int) soundPos.y, (int) soundPos.z);
+        BlockPos soundBlockPos = BlockPos.containing(soundPos);
 
         Loggers.logDebug("Player pos: {}, {}, {} \tSound Pos: {}, {}, {} \tTo player vector: {}, {}, {}", playerPos.x, playerPos.y, playerPos.z, soundPos.x, soundPos.y, soundPos.z, normalToPlayer.x, normalToPlayer.y, normalToPlayer.z);
 
@@ -482,7 +482,7 @@ public class SoundPhysics {
         double variationFactor = SoundPhysicsMod.CONFIG.occlusionVariation.get();
 
         if (isBlock) {
-            variationFactor = Math.max(variationFactor, 0.501D);
+            variationFactor = Math.max(variationFactor, 0.5D);
         }
 
         double occlusionAccMin = Double.MAX_VALUE;
@@ -512,7 +512,7 @@ public class SoundPhysics {
         double occlusionAccumulation = 0D;
         Vec3 rayOrigin = soundPos;
 
-        BlockPos lastBlockPos = new BlockPos((int) soundPos.x, (int) soundPos.y, (int) soundPos.z);
+        BlockPos lastBlockPos = BlockPos.containing(soundPos);
 
         for (int i = 0; i < SoundPhysicsMod.CONFIG.maxOcclusionRays.get(); i++) {
             BlockHitResult rayHit = RaycastUtils.rayCast(getLevelProxy(), rayOrigin, playerPos, lastBlockPos);

--- a/common/src/main/java/com/sonicether/soundphysics/utils/LevelAccessUtils.java
+++ b/common/src/main/java/com/sonicether/soundphysics/utils/LevelAccessUtils.java
@@ -123,6 +123,6 @@ public class LevelAccessUtils {
 
     private static BlockPos levelOriginFromPlayer() {
         var playerPos = MC.player.position();
-        return new BlockPos((int) playerPos.x, (int) playerPos.y, (int) playerPos.z);
+        return BlockPos.containing(playerPos);
     }
 }


### PR DESCRIPTION
Fix weird muffling issues.
Also changed `variationFactor` because keeping it to 0.501 caused sounds to phase through 1 block wall and never muffles.

https://github.com/henkelmax/sound-physics-remastered/assets/68376185/0cf8caf0-c8a8-4737-8de9-f7af7c46a0bc