### PR TITLE
Added hotfix for distance based attenuation for reverb

### DIFF
--- a/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
+++ b/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
@@ -349,6 +349,10 @@ public class SoundPhysics {
                             audioDirection.addSharedAirspace(sharedAirspaceVector, totalRayDistance);
                         }
                     }
+                    // Bandaid solution for distance based attenuation
+                    if (Math.max(totalRayDistance, 0D) <= SoundPhysicsMod.CONFIG.reverbAttenuationDistance.get()) {
+                        continue;
+                    }
 
                     float reflectionDelay = (float) Math.max(totalRayDistance, 0D) * 0.12F * blockReflectivity;
 

--- a/common/src/main/java/com/sonicether/soundphysics/config/SoundPhysicsConfig.java
+++ b/common/src/main/java/com/sonicether/soundphysics/config/SoundPhysicsConfig.java
@@ -11,6 +11,7 @@ public class SoundPhysicsConfig {
     public final ConfigEntry<Boolean> enabled;
 
     public final ConfigEntry<Float> attenuationFactor;
+    public final ConfigEntry<Float> reverbAttenuationDistance;
     public final ConfigEntry<Float> reverbGain;
     public final ConfigEntry<Float> reverbBrightness;
     public final ConfigEntry<Float> reverbDistance;
@@ -60,6 +61,9 @@ public class SoundPhysicsConfig {
                         "This setting requires you to be in singleplayer or having the mod installed on the server",
                         "1.0 is the physically correct value"
                 );
+        reverbAttenuationDistance = builder
+                .floatEntry("reverb_attenuation_distance", 32F, 0F, 512F)
+                .comment("The distance at which reverb attenuation starts");
         reverbGain = builder
                 .floatEntry("reverb_gain", 1F, 0.1F, 2F)
                 .comment("The volume of simulated reverberations");

--- a/common/src/main/java/com/sonicether/soundphysics/integration/ClothConfigIntegration.java
+++ b/common/src/main/java/com/sonicether/soundphysics/integration/ClothConfigIntegration.java
@@ -54,6 +54,11 @@ public class ClothConfigIntegration {
                 SoundPhysicsMod.CONFIG.attenuationFactor
         ));
         general.addEntry(fromConfigEntry(entryBuilder,
+                Component.translatable("cloth_config.sound_physics_remastered.reverb_attenuation_distance"), 
+                Component.translatable("cloth_config.sound_physics_remastered.reverb_attenuation_distance.description"),
+                SoundPhysicsMod.CONFIG.reverbAttenuationDistance
+        ));
+        general.addEntry(fromConfigEntry(entryBuilder,
                 Component.translatable("cloth_config.sound_physics_remastered.reverb_gain"),
                 Component.translatable("cloth_config.sound_physics_remastered.reverb_gain.description"),
                 SoundPhysicsMod.CONFIG.reverbGain

--- a/common/src/main/resources/assets/sound_physics_remastered/lang/en_us.json
+++ b/common/src/main/resources/assets/sound_physics_remastered/lang/en_us.json
@@ -15,6 +15,8 @@
   "cloth_config.sound_physics_remastered.simple_voice_chat_hear_self.description": "Enables/Disables hearing your own echo with Simple Voice Chat.",
   "cloth_config.sound_physics_remastered.attenuation_factor": "Attenuation factor",
   "cloth_config.sound_physics_remastered.attenuation_factor.description": "Affects how quiet a sound gets based on distance. Lower values mean distant sounds are louder. This setting requires you to be in singleplayer or having the mod installed on the server. 1.0 is the physically correct value.",
+  "cloth_config.sound_physics_remastered.reverb_attenuation_distance": "Reverb attenuation distance",
+  "cloth_config.sound_physics_remastered.reverb_attenuation_distance.description": "Distance which reverb attenuation is applied.",
   "cloth_config.sound_physics_remastered.reverb_gain": "Reverb gain",
   "cloth_config.sound_physics_remastered.reverb_gain.description": "The volume of simulated reverberations.",
   "cloth_config.sound_physics_remastered.reverb_brightness": "Reverb brightness",


### PR DESCRIPTION
Added a variable `reverbAttenuationDistance` which allows you to determine how far a ray has to travel before it contributes to reverb. If the distance a ray traveled before reaching the player is less than this distance no gain is added and the next ray is computed.

This allows for small interiors to have no reverb which makes smaller rooms with reflective materials dry which is closer to reality, but not perfect. This is a good temporary fix for those who want caves and large buildings to echo but not their house.

A positive side effect is narrow halls leading into open caverns have more directionality to the sound since rays that have shorter paths don't contribute to the reverb, meaning only rays from the cavern add to the reverb.

Overall this is just a hotfix that allows you to configure what size spaces reverb will occur in.