### PR TITLE
Add sound-specific configs (#288)

### DIFF
--- a/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
+++ b/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
@@ -235,7 +235,7 @@ public class SoundPhysics {
         }
 
         float directCutoff;
-        float absorptionCoeff = (float) (SoundPhysicsMod.CONFIG.blockAbsorption.get() * 3D);
+        float absorptionCoeff = (float) (SoundPhysicsMod.CONFIG.blockAbsorption.get() * SoundPhysicsMod.SOUND_ABSORPTION_CONFIG.getValue(sound) * 3D);
 
         // Direct sound occlusion
 
@@ -327,7 +327,7 @@ public class SoundPhysics {
 
                     BlockHitResult newRayHit = RaycastUtils.rayCast(getLevelProxy(), newRayStart, newRayEnd, lastHitBlock);
 
-                    float blockReflectivity = getBlockReflectivity(lastHitBlock);
+                    float blockReflectivity = getBlockReflectivity(lastHitBlock) * SoundPhysicsMod.SOUND_REFLECTIVITY_CONFIG.getValue(sound);
                     float energyTowardsPlayer = 0.25F * (blockReflectivity * 0.75F + 0.25F);
 
                     if (newRayHit.getType() == HitResult.Type.MISS) {

--- a/common/src/main/java/com/sonicether/soundphysics/SoundPhysicsMod.java
+++ b/common/src/main/java/com/sonicether/soundphysics/SoundPhysicsMod.java
@@ -1,9 +1,6 @@
 package com.sonicether.soundphysics;
 
-import com.sonicether.soundphysics.config.OcclusionConfig;
-import com.sonicether.soundphysics.config.ReflectivityConfig;
-import com.sonicether.soundphysics.config.AllowedSoundConfig;
-import com.sonicether.soundphysics.config.SoundPhysicsConfig;
+import com.sonicether.soundphysics.config.*;
 import de.maxhenkel.configbuilder.ConfigBuilder;
 
 import java.nio.file.Path;
@@ -16,6 +13,8 @@ public abstract class SoundPhysicsMod {
     public static ReflectivityConfig REFLECTIVITY_CONFIG;
     public static OcclusionConfig OCCLUSION_CONFIG;
     public static AllowedSoundConfig ALLOWED_SOUND_CONFIG;
+    public static SoundAbsorptionConfig SOUND_ABSORPTION_CONFIG;
+    public static SoundReflectivityConfig SOUND_REFLECTIVITY_CONFIG;
 
     public void init() {
         initConfig();
@@ -28,6 +27,8 @@ public abstract class SoundPhysicsMod {
         REFLECTIVITY_CONFIG = new ReflectivityConfig(getConfigFolder().resolve(MODID).resolve("reflectivity.properties"));
         OCCLUSION_CONFIG = new OcclusionConfig(getConfigFolder().resolve(MODID).resolve("occlusion.properties"));
         ALLOWED_SOUND_CONFIG = new AllowedSoundConfig(getConfigFolder().resolve(MODID).resolve("allowed_sounds.properties"));
+        SOUND_ABSORPTION_CONFIG = new SoundAbsorptionConfig(getConfigFolder().resolve(MODID).resolve("sound_absorption.properties"));
+        SOUND_REFLECTIVITY_CONFIG = new SoundReflectivityConfig(getConfigFolder().resolve(MODID).resolve("sound_reflectivity.properties"));
     }
 
     private void initConfig() {

--- a/common/src/main/java/com/sonicether/soundphysics/config/SoundAbsorptionConfig.java
+++ b/common/src/main/java/com/sonicether/soundphysics/config/SoundAbsorptionConfig.java
@@ -15,11 +15,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 
-public class AllowedSoundConfig extends CommentedPropertyConfig {
+public class SoundAbsorptionConfig extends CommentedPropertyConfig {
 
-    private Map<String, Boolean> allowedSounds;
+    private Map<String, Float> soundAbsorptions;
 
-    public AllowedSoundConfig(Path path) {
+    public SoundAbsorptionConfig(Path path) {
         super(new CommentedProperties(false));
         this.path = path;
         reload();
@@ -29,13 +29,13 @@ public class AllowedSoundConfig extends CommentedPropertyConfig {
     public void load() throws IOException {
         super.load();
 
-        Map<String, Boolean> map = createDefaultMap();
+        Map<String, Float> map = createDefaultMap();
 
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             String key = entry.getKey();
-            boolean value;
+            float value;
             try {
-                value = Boolean.parseBoolean(entry.getValue());
+                value = Float.parseFloat(entry.getValue());
             } catch (Exception e) {
                 Loggers.warn("Failed to set allowed sound entry {}", key);
                 continue;
@@ -55,7 +55,7 @@ public class AllowedSoundConfig extends CommentedPropertyConfig {
             map.put(resourceLocation.toString(), value);
         }
 
-        allowedSounds = ConfigUtils.sortMap(map);
+        soundAbsorptions = ConfigUtils.sortMap(map);
 
         saveSync();
     }
@@ -75,34 +75,40 @@ public class AllowedSoundConfig extends CommentedPropertyConfig {
     public void saveSync() {
         properties.clear();
 
-        properties.addHeaderComment("Allowed sounds");
-        properties.addHeaderComment("Set to 'false' to disable sound physics for that sound");
+        properties.addHeaderComment("Sound specific absorption multipliers");
 
-        for (Map.Entry<String, Boolean> entry : allowedSounds.entrySet()) {
+        for (Map.Entry<String, Float> entry : soundAbsorptions.entrySet()) {
             properties.set(entry.getKey(), String.valueOf(entry.getValue()));
         }
 
         super.saveSync();
     }
 
-    public Map<String, Boolean> getAllowedSounds() {
-        return allowedSounds;
+    public Map<String, Float> getMap() {
+        return soundAbsorptions;
     }
 
-    public boolean isAllowed(String soundEvent) {
-        return allowedSounds.getOrDefault(soundEvent, true);
+    public float getValue(String soundEvent) {
+        return soundAbsorptions.getOrDefault(soundEvent, 1.0F);
     }
 
-    public Map<String, Boolean> createDefaultMap() {
-        Map<String, Boolean> map = new HashMap<>();
+    public Map<String, Float> createDefaultMap() {
+        Map<String, Float> map = new HashMap<>();
         for (SoundEvent event : BuiltInRegistries.SOUND_EVENT) {
-            map.put(event.getLocation().toString(), true);
+            map.put(event.getLocation().toString(), 1.0F);
         }
 
-        map.put(SoundEvents.WEATHER_RAIN.getLocation().toString(), false);
-        map.put(SoundEvents.WEATHER_RAIN_ABOVE.getLocation().toString(), false);
+        map.put(SoundEvents.LIGHTNING_BOLT_THUNDER.getLocation().toString(), 0.2F);
+        map.put(SoundEvents.GENERIC_EXPLODE.getLocation().toString(), 0.2F);
+        SoundEvents.GOAT_HORN_SOUND_VARIANTS.forEach(r -> map.put(r.key().location().toString(), 0.25F));
 
         return map;
+    }
+
+    public void setValue(String key, float value) {
+        Map<String, Float> map = soundAbsorptions;
+        map.put(key, value);
+        soundAbsorptions = map;
     }
 
 }

--- a/common/src/main/java/com/sonicether/soundphysics/integration/ClothConfigIntegration.java
+++ b/common/src/main/java/com/sonicether/soundphysics/integration/ClothConfigIntegration.java
@@ -197,6 +197,34 @@ public class ClothConfigIntegration {
             occlusion.addEntry(e);
         }
 
+        ConfigCategory sound_absorption = builder.getOrCreateCategory(Component.translatable("cloth_config.sound_physics_remastered.category.sound_absorption"));
+
+        Map<String, Float> defaultSoundAbsorptionMap = SoundPhysicsMod.SOUND_ABSORPTION_CONFIG.createDefaultMap();
+
+        for (Map.Entry<String, Float> entry : SoundPhysicsMod.SOUND_ABSORPTION_CONFIG.getMap().entrySet()) {
+            FloatListEntry e = entryBuilder
+                    .startFloatField(Component.nullToEmpty(entry.getKey()), entry.getValue())
+                    .setMin(0.01F)
+                    .setMax(10F)
+                    .setDefaultValue(defaultSoundAbsorptionMap.getOrDefault(entry.getKey(), 1F))
+                    .setSaveConsumer(value -> SoundPhysicsMod.SOUND_ABSORPTION_CONFIG.setValue(entry.getKey(), value)).build();
+            sound_absorption.addEntry(e);
+        }
+
+        ConfigCategory sound_reflectivity = builder.getOrCreateCategory(Component.translatable("cloth_config.sound_physics_remastered.category.sound_reflectivity"));
+
+        Map<String, Float> defaultSoundReflectivityMap = SoundPhysicsMod.SOUND_REFLECTIVITY_CONFIG.createDefaultMap();
+
+        for (Map.Entry<String, Float> entry : SoundPhysicsMod.SOUND_REFLECTIVITY_CONFIG.getMap().entrySet()) {
+            FloatListEntry e = entryBuilder
+                    .startFloatField(Component.nullToEmpty(entry.getKey()), entry.getValue())
+                    .setMin(0.01F)
+                    .setMax(10F)
+                    .setDefaultValue(defaultSoundReflectivityMap.getOrDefault(entry.getKey(), 1F))
+                    .setSaveConsumer(value -> SoundPhysicsMod.SOUND_REFLECTIVITY_CONFIG.setValue(entry.getKey(), value)).build();
+            sound_reflectivity.addEntry(e);
+        }
+
         ConfigCategory logging = builder.getOrCreateCategory(Component.translatable("cloth_config.sound_physics_remastered.category.debug"));
 
         logging.addEntry(fromConfigEntry(entryBuilder,
@@ -236,6 +264,8 @@ public class ClothConfigIntegration {
             SoundPhysicsMod.REFLECTIVITY_CONFIG.save();
             SoundPhysicsMod.OCCLUSION_CONFIG.save();
             SoundPhysicsMod.ALLOWED_SOUND_CONFIG.save();
+            SoundPhysicsMod.SOUND_ABSORPTION_CONFIG.save();
+            SoundPhysicsMod.SOUND_REFLECTIVITY_CONFIG.save();
             SoundPhysicsMod.CONFIG.reloadClient();
         });
 

--- a/common/src/main/resources/assets/sound_physics_remastered/lang/en_us.json
+++ b/common/src/main/resources/assets/sound_physics_remastered/lang/en_us.json
@@ -5,6 +5,8 @@
   "cloth_config.sound_physics_remastered.category.performance": "Performance",
   "cloth_config.sound_physics_remastered.category.reflectivity": "Block Reflectivities",
   "cloth_config.sound_physics_remastered.category.occlusion": "Block Occlusion Factors",
+  "cloth_config.sound_physics_remastered.category.sound_absorption": "Sound Occlusion Factors",
+  "cloth_config.sound_physics_remastered.category.sound_reflectivity": "Sound Reflectivity Factors",
   "cloth_config.sound_physics_remastered.category.debug": "Debug",
 
   "cloth_config.sound_physics_remastered.enabled": "Enable Sound Physics",


### PR DESCRIPTION
Implementation of sound-specific absorption and reflectivity factors via config w/ GUI support. Additionally, thunder and goat horns are no longer excluded from receiving sound physics as they can be better supported with the changes listed previously. Also, explosions are modified by default the same way that thunder is.

The values chosen so far for default values are what I believe to be okay values without completely compromising the sound physics for them.

To be honest, the way it is implemented kind of feels like a band-aid solution, but without truly understanding how all the sounds physics processing works, I feel as if its the best I can do without feedback.

Please let me know what changes need to be made, if any.

note:
*I've only tested it for fabric but I presume its simple enough that it won't be affected by modloader, especially since it is fundamentally two new configs and just multiplying those values into the SoundPhysics class*