### PR TITLE
Fix sound muffling for underwater sources

### DIFF
--- a/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
+++ b/common/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.level.material.FluidState;
 
 public class SoundPhysics {
 
@@ -243,6 +244,8 @@ public class SoundPhysics {
         Vec3 normalToPlayer = playerPos.subtract(soundPos).normalize();
 
         BlockPos soundBlockPos = BlockPos.containing(soundPos);
+        FluidState soundFluidState = getLevelProxy().getFluidState(soundBlockPos);
+        boolean sourceIsUnderwater = soundFluidState.is(net.minecraft.world.level.material.Fluids.WATER);
 
         Loggers.logDebug("Player pos: {}, {}, {} \tSound Pos: {}, {}, {} \tTo player vector: {}, {}, {}", playerPos.x, playerPos.y, playerPos.z, soundPos.x, soundPos.y, soundPos.z, normalToPlayer.x, normalToPlayer.y, normalToPlayer.z);
 
@@ -265,7 +268,7 @@ public class SoundPhysics {
         float sendCutoff2 = 1F;
         float sendCutoff3 = 1F;
 
-        if (minecraft.player.isUnderWater()) {
+        if (minecraft.player.isUnderWater() || sourceIsUnderwater) {
             directCutoff *= 1F - SoundPhysicsMod.CONFIG.underwaterFilter.get();
         }
 
@@ -442,7 +445,7 @@ public class SoundPhysics {
         Loggers.logEnvironment("Final environment settings: {}, {}, {}, {}", sendGain0, sendGain1, sendGain2, sendGain3);
 
         assert minecraft.player != null;
-        if (minecraft.player.isUnderWater()) {
+        if (minecraft.player.isUnderWater() || sourceIsUnderwater) {
             sendCutoff0 *= 0.4F;
             sendCutoff1 *= 0.4F;
             sendCutoff2 *= 0.4F;


### PR DESCRIPTION
This PR fixes the behavior where sound muffling was only applied when the listener was underwater. Now, the muffling effect also applies when the source is underwater, regardless of the listener’s position. This improves realism, especially for cases like underwater explosions or players speaking underwater with proximity voice chat.